### PR TITLE
Joehoski/replace wrong tutorial link

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -276,7 +276,7 @@ $(document).ready(function () {
 <a class="list-group-item" href="Tutorials/Numerical Descriptives">Tutorials: Numerical Descriptives</a>
 <a class="list-group-item" href="Tutorials/Intro to R">Tutorials: Intro to R</a>
 <a class="list-group-item" href="Tutorials/t Tests">Tutorials: t Tests</a>
-<a class="list-group-item" href="Tutorials/rtutorial4">Tutorials: rtutorial4</a>
+<a class="list-group-item" href="Tutorials/Correlation and Regression">Tutorials: Correlation and Regression</a>
 <a class="list-group-item" href="PSYC_Tutorials/R Dataset Cleaning/">PSYC: R Dataset Cleaning</a>
 <a class="list-group-item" href="PSYC_Tutorials/R Functions/">PSYC: R Functions</a>
 <a class="list-group-item" href="PSYC_Tutorials/R Subsetting/">PSYC: R Subsetting</a>

--- a/index.Rmd
+++ b/index.Rmd
@@ -35,8 +35,8 @@ library(htmltools)
           ),
           a(
             class="list-group-item",
-            "Tutorials: rtutorial4",
-            href="Tutorials/rtutorial4"
+            "Tutorials: Correlation and Regression",
+            href="Tutorials/Correlation and Regression"
           ),
           a(
             class="list-group-item",


### PR DESCRIPTION
Correct link to tutorial.

The rtutorial4 link was misnamed and resulted in a 404 error. Replaced it with a link to the Correlation and Regression tutorial which wasn't previously linked to. A link to that tutorial should now show in the side navigation bar and there should be no rtutorial4 link.