### PR TITLE
Joehoski/allow user to proceed from sandbox exercise

### DIFF
--- a/Tutorials/Correlation and Regression/Regression.Rmd
+++ b/Tutorials/Correlation and Regression/Regression.Rmd
@@ -95,7 +95,7 @@ cor(swiss$Infant.Mortality,swiss$Fertility, method = 'pearson')
 
 ## Regression
 
-###
+### {data-allow-skip=TRUE}
 Before starting the module, if you need a review on the concepts of regression, feel free to watch the video. ![Linear Regression](https://www.youtube.com/watch?v=i032e6OGzUA)
 
 We'll start by looking at the relationship between fertility measures and the proportion of people having education beyond primary level.

--- a/_site/Tutorials/Correlation and Regression/Regression.Rmd
+++ b/_site/Tutorials/Correlation and Regression/Regression.Rmd
@@ -95,7 +95,7 @@ cor(swiss$Infant.Mortality,swiss$Fertility, method = 'pearson')
 
 ## Regression
 
-###
+### {data-allow-skip=TRUE}
 Before starting the module, if you need a review on the concepts of regression, feel free to watch the video. ![Linear Regression](https://www.youtube.com/watch?v=i032e6OGzUA)
 
 We'll start by looking at the relationship between fertility measures and the proportion of people having education beyond primary level.


### PR DESCRIPTION
Allows user to proceed from sandbox (practice) exercise.

In the subtopic for regression, previously the tutorial would not allow the user to proceed by clicking next until the user both completed the video and ran some code in the practice exercise. I removed this requirement to make it less confusing for the user.